### PR TITLE
fix(bug#216) : fix du bug d'affichage des pages detail annonce et proposition

### DIFF
--- a/Web App Frontend/src/Pages/DetailAnnonce/DetailAnnonce.js
+++ b/Web App Frontend/src/Pages/DetailAnnonce/DetailAnnonce.js
@@ -104,7 +104,7 @@ function DetailAnnonce() {
    * Vérifie si la personne ne c'est pas encore proposer pour cette annonce
    */
   useEffect(() => {
-    getHelpGived(JSON.parse(localStorage.getItem("user")).id,annonce.id);
+    getHelpGived(JSON.parse(localStorage.getItem("user")) == null ? 0 : JSON.parse(localStorage.getItem("user")).id ,annonce.id);
     // eslint-disable-next-line
   }, [annonce]);
 
@@ -265,7 +265,7 @@ function DetailAnnonce() {
             <Col xs={{ span: 3, offset: 8 }}>
               <Button className="delete-button" onClick={() => deleteAnnonce(annonce.id)}>Supprimer</Button>
             </Col>
-          ) : helpGive ? <Col xs={{ span: 3, offset: 8 }}>
+          ) : helpGive && JSON.parse(localStorage.getItem("user")) != null ? <Col xs={{ span: 3, offset: 8 }}>
                 <Button variant="success" className="proposition-button" onClick={() => {sendHelp(annonce.id,JSON.parse(localStorage.getItem("user")).id);setShowNotif(true);}}>Proposer</Button>
               </Col> : null
         }

--- a/Web App Frontend/src/Pages/DetailProposition/DetailProposition.js
+++ b/Web App Frontend/src/Pages/DetailProposition/DetailProposition.js
@@ -95,7 +95,7 @@ function DetailProposition() {
    * Vérifie si la personne ne c'est pas encore proposer pour cette proposition
    */
   useEffect(() => {
-    getHelpAsked(JSON.parse(localStorage.getItem("user")).id,proposition.id);
+    getHelpAsked(JSON.parse(localStorage.getItem("user")) == null ? 0 : JSON.parse(localStorage.getItem("user")).id ,proposition.id);
     // eslint-disable-next-line
   }, [proposition]);
 
@@ -249,7 +249,8 @@ function DetailProposition() {
             <Col xs={{ span: 3, offset: 8 }}>
               <Button className="delete-button" onClick={() => deleteProposition(proposition.id)}>Supprimer</Button>
             </Col>
-          ) : helpAsked ? <Col xs={{ span: 3, offset: 8 }}>
+          ) : helpAsked && JSON.parse(localStorage.getItem("user")) != null? <Col xs={{ span: 3, offset: 8 }}>
+          
           <Button variant="success" className="proposition-button" onClick={() => {askHelp(proposition.id,JSON.parse(localStorage.getItem("user")).id);setShowNotif(true);}}>Demander</Button>
         </Col> : null}
         </Row>


### PR DESCRIPTION
On avait une page blanche lorsqu'on était déconnecté et qu'on voulais afficher les detail d'une annonce ou d'une proposition

Pour avoir le bug il falait juste être déconnecter et cliquer sur un proposition ou annonce pou voir le bug afficher

Donc pour éviter ca il a fallu rajouter des condition dans le cas ou le user.id est null et qu'il soit considérer comme un zéro Il a aussi fallut mettre une condition a l'affichage des boutton qui mette les gens en relation pour éviter qu'un inconnu puisse intéragire avec les propositions et annonces

closes #216