### PR TITLE
fix(bug#218):fix du bug d'affichage de l'age des user

### DIFF
--- a/Web App Frontend/src/Pages/DetailProposition/DetailProposition.js
+++ b/Web App Frontend/src/Pages/DetailProposition/DetailProposition.js
@@ -195,6 +195,18 @@ function DetailProposition() {
 
     }
   }
+  
+  function Age(date){
+    var an=date.substr(0,4);
+    var mois=date.substr(5,2);
+    var day= date.substr(8,2); 
+    var dateNaissance = new Date(an + "-" + mois + "-" + day);
+
+    var diff = Date.now() - dateNaissance.getTime();
+    var age = new Date(diff); 
+
+    return Math.abs(age.getUTCFullYear() - 1970)
+  }
 
   return (
     <div className="DetailProposition">
@@ -260,7 +272,7 @@ function DetailProposition() {
           <Row>
             <Col>
               <h3>
-                Proposition de {proposition.User.Firstname}, {proposition.User.Age} ans
+                Proposition de {proposition.User.Firstname}, {Age(proposition.User.Age)} ans
               </h3>
             </Col>
           </Row>


### PR DESCRIPTION
En allant sur les annonces des utilisateur créer après la création de la db, l'affichage de l'age n'est plus correct. Il nous affichais l'age sous forme YYYY-MM-DD et non réellement l'age.

Pour afficher le bug il fallait cliquer sur une proposition d'un nouvel utilisateur

Pour éviter ca il a fallut faire un prétraitement de la valeur stockée dans la db affins de pouvoir la calculé comme une date en JS

closes #218